### PR TITLE
Replace hard coded initial Snake length

### DIFF
--- a/src/board/BoardLogic.java
+++ b/src/board/BoardLogic.java
@@ -84,7 +84,7 @@ public class BoardLogic {
                 // Then check if this random field an the num of BoardLogic.START_LENGTH left fields are free.
                 isFree = true;
                 for (int i = 0; i < BoardLogic.START_LENGTH; i++) {
-                    if (((random.getPosX() + 2) >= BoardLogic.MAX_X) || !fields[random.getPosX() + i][random.getPosY()].isFree()) {
+                    if (((random.getPosX() + BoardLogic.START_LENGTH) > BoardLogic.MAX_X) || !fields[random.getPosX() + i][random.getPosY()].isFree()) {
 
                         isFree = false;
                         break;


### PR DESCRIPTION
Thanks to jakob for finding the bug and providing a fix!

 Jakob: Hab gerade noch einen kleinen Fehler entdeckt. Sobald man die Anfangs-Länge der Schlagen (in snake_arena.properties) verändert, kann es dazu kommen, dass man eine "ArrayIndexOutOfBounds"-Exception bekommt. Das passiert, weil in BoardLogic.java in Zeile 87 immer davon ausgegangen wird, dass alle Schlangen eine Länge von 3 haben. Das führt dazu, dass bei der Verteilung unter Umständen der Schlagen Felder überprüft werden, die gar nicht existieren, weil sie außerhalb des Boards liegen.

  Um's zu fixen einfach die Zeile:
  `if (((random.getPosX() + 2) >= BoardLogic.MAX_X) || !fields[random.getPosX() + i][random.getPosY()].isFree()) {`
  durch die hier ersetzen:
  `if (((random.getPosX() + BoardLogic.START_LENGTH) > BoardLogic.MAX_X) || !fields[random.getPosX() + i][random.getPosY()].isFree()) {`